### PR TITLE
5 edit person role

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -21,7 +21,7 @@ class Admin::PeopleController < Admin::ApplicationController
     if @person.update(person_params)
       redirect_to admin_people_path, flash: { info: "#{@person.name} was successfully updated." }
     else
-      render :edit, locals: { person: person }
+      render :edit, locals: { person: @person }
     end
   end
 

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -41,6 +41,6 @@ class Admin::PeopleController < Admin::ApplicationController
     # Only allow a trusted parameter "white list" through.
     def person_params
       params.require(:person).permit(:bio, :gender, :ethnicity, :country,
-                                     :name, :email)
+                                     :name, :email, :role)
     end
 end

--- a/app/controllers/organizer/application_controller.rb
+++ b/app/controllers/organizer/application_controller.rb
@@ -6,7 +6,11 @@ class Organizer::ApplicationController < ApplicationController
 
   def require_event
     @event = current_user &&
-      current_user.organizer_events.find(params[:event_id] || params[:id])
+      if current_user.global_organizer?
+        Event.find_by_id(params[:event_id] || params[:id])
+      else
+        current_user.organizer_events.find(params[:event_id] || params[:id])
+      end
   end
 
   # Must be an organizer on @event

--- a/app/controllers/reviewer/application_controller.rb
+++ b/app/controllers/reviewer/application_controller.rb
@@ -19,7 +19,9 @@ class Reviewer::ApplicationController < ApplicationController
   end
 
   def require_event
-    @event = current_user.reviewer_events.find(params[:event_id] || params[:id])
+    @event = current_user.global_reviewer? ?
+      Event.find_by_id(params[:event_id] || params[:id]) :
+      current_user.reviewer_events.find(params[:event_id] || params[:id])
   end
 
   # Prevent reviewers from reviewing their own proposals

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -15,7 +15,7 @@ class EventDecorator < ApplicationDecorator
   end
 
   def path_for(person)
-    path = if person && person.organizer_for_event?(object)
+    path = if person && (person.organizer_for_event?(object) || person.global_organizer?)
       h.organizer_event_proposals_path(object)
     else
       h.event_path(object.slug)

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -11,4 +11,24 @@ class PersonDecorator < ApplicationDecorator
       h.proposal_path(event.slug, proposal)
     end
   end
+
+  # Allows selection of Events for review for interface display, based on 
+  #  'global' status, or available Participation associations.
+  def all_reviewer_events
+    if global_reviewer?
+      Event.live.recent
+    else
+      object.reviewer_events
+    end
+  end
+
+  # Allows selection of Events for organization for interface display, based on
+  #  'global' status, or available Participation associations.
+  def all_organizer_events
+    if global_organizer?
+      Event.live.recent
+    else
+      object.organizer_events
+    end
+  end
 end

--- a/app/mailers/comment_notification_mailer.rb
+++ b/app/mailers/comment_notification_mailer.rb
@@ -9,6 +9,14 @@ class CommentNotificationMailer < ApplicationMailer
       end
     end.compact
 
+    # 'Global' reviewers and organizers aren't always a Participant of the 
+    #  current event, so add them as well.
+    Person.global_reviewers.each { |person|
+      unless bcc.include? person.email
+        bcc << person.email
+      end
+    }
+
     if bcc.any?
       mail_markdown(bcc: bcc,
            from: @comment.proposal.event.contact_email,

--- a/app/models/concerns/roles.rb
+++ b/app/models/concerns/roles.rb
@@ -1,0 +1,10 @@
+# Defines role types, which are used throughout application models, various
+#  procedures, and structures.
+module Roles
+  # @see comment in Proposal::State for issue on consts defined 2x.
+  unless const_defined?(:ROLES)
+    ROLE_ORGANIZER = 'organizer'
+    ROLE_REVIEWER  = 'reviewer'
+    ROLE_TYPES     = [ROLE_ORGANIZER, ROLE_REVIEWER]
+  end
+end

--- a/app/models/concerns/roles.rb
+++ b/app/models/concerns/roles.rb
@@ -2,7 +2,7 @@
 #  procedures, and structures.
 module Roles
   # @see comment in Proposal::State for issue on consts defined 2x.
-  unless const_defined?(:ROLES)
+  unless const_defined?(:ROLE_TYPES)
     ROLE_ORGANIZER = 'organizer'
     ROLE_REVIEWER  = 'reviewer'
     ROLE_TYPES     = [ROLE_ORGANIZER, ROLE_REVIEWER]

--- a/app/views/admin/people/_form.html.haml
+++ b/app/views/admin/people/_form.html.haml
@@ -1,4 +1,12 @@
 = form_for [:admin, person] do |f|
+  = if person.errors.any?
+    %div
+      %h2
+        = pluralize(person.errors.count, 'error') << ' prohibited this Person from being saved:'
+      %ul
+      - person.errors.full_messages.each do |message|
+        %li
+          = message
   .row
     %fieldset.col-md-6
       %h2 Person
@@ -14,6 +22,11 @@
         = f.text_area :bio, class: 'form-control', placeholder: 'Bio', rows: 8
 
     %fieldset.col-md-4
+      %h2 Global Role
+      %p
+      .form-group
+        = f.label :role
+        = f.select :role, options_for_select(Roles::ROLE_TYPES, person.role), { include_blank: true }, class: 'form-control'
       %h2 Demographics
       %p= render :partial => 'shared/demographics', :locals => {:f => f}
 

--- a/app/views/admin/people/_person.html.haml
+++ b/app/views/admin/people/_person.html.haml
@@ -1,7 +1,7 @@
 %tr
   %td= link_to person.name, admin_person_path(person)
   %td= person.email
-  %td= person.role_names
+  %td= person.role
   %td= person.created_at
   %td.actions
     = link_to 'Edit', edit_admin_person_path(person), class: 'btn btn-primary btn-xs'

--- a/app/views/admin/people/show.html.haml
+++ b/app/views/admin/people/show.html.haml
@@ -11,6 +11,7 @@
           %p
             = "#{type}:"
             = person.demographics[type.to_s]
+    %h5 Role
     %h5 Bio
     %p
       = person.bio

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -47,7 +47,7 @@
                     Review
                     %b.caret
                   %ul.dropdown-menu
-                    - current_user.reviewer_events.each do |event|
+                    - current_user.decorate.all_reviewer_events.each do |event|
                       -unless event.archived?
                         %li= link_to event, reviewer_event_proposals_path(event)
               - if current_user.organizer?
@@ -56,7 +56,7 @@
                     Organize
                     %b.caret
                   %ul.dropdown-menu
-                    - current_user.organizer_events.each do |event|
+                    - current_user.decorate.all_organizer_events.each do |event|
                       %li
                         -unless event.archived?
                           = link_to event, organizer_event_path(event)

--- a/db/migrate/20151023163637_add_role_to_person.rb
+++ b/db/migrate/20151023163637_add_role_to_person.rb
@@ -1,0 +1,5 @@
+class AddRoleToPerson < ActiveRecord::Migration
+  def change
+    add_column :people, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150604225912) do
+ActiveRecord::Schema.define(version: 20151023163637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,11 +70,11 @@ ActiveRecord::Schema.define(version: 20150604225912) do
 
   create_table "notifications", force: true do |t|
     t.integer  "person_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
     t.string   "message"
     t.datetime "read_at"
     t.string   "target_path"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "notifications", ["person_id"], name: "index_notifications_on_person_id", using: :btree
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 20150604225912) do
     t.boolean  "admin",        default: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "role"
   end
 
   create_table "proposals", force: true do |t|
@@ -120,11 +121,11 @@ ActiveRecord::Schema.define(version: 20150604225912) do
     t.text     "abstract"
     t.text     "details"
     t.text     "pitch"
+    t.text     "last_change"
+    t.text     "confirmation_notes"
     t.datetime "confirmed_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "last_change"
-    t.text     "confirmation_notes"
     t.datetime "updated_by_speaker_at"
     t.text     "proposal_data"
   end

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -16,4 +16,43 @@ describe PersonDecorator do
         eq(h.reviewer_event_proposal_path(proposal.event, proposal)))
     end
   end
+
+  describe 'reviewer and organizer event lists' do
+    let(:global_reviewer) { create(:person, :global_reviewer) }
+    let(:global_organizer) { create(:person, :global_organizer) }
+    let(:person_without_participants) { create(:person) }
+    let!(:person) { create(:person) }    
+    let!(:event) { create(:event, state: 'open') }
+    let!(:event_without_participants) { create(:event, state: 'open') }
+    let!(:participant) { create(:participant, event: event, person: person, role: Roles::ROLE_ORGANIZER) }
+
+
+    describe '#all_reviewer_events' do
+      it 'returns the event for the global reviewer' do
+        expect(global_reviewer.decorate.all_reviewer_events).to contain_exactly(event, event_without_participants)
+      end
+
+      it 'returns only event for non global person' do
+        expect(person.decorate.all_reviewer_events).to(eq([event]))
+      end
+
+      it 'does not return events for the person with no participants' do
+        expect(person_without_participants.decorate.all_reviewer_events).to be_empty
+      end
+    end
+
+    describe '#all_organizer_events' do
+      it 'returns all events for the global organizer' do
+        expect(global_organizer.decorate.all_organizer_events).to contain_exactly(event, event_without_participants)
+      end
+
+      it 'returns only event for non global person' do
+        expect(person.decorate.all_organizer_events).to(eq([event]))
+      end
+
+      it 'does not return events for the person with no participants' do
+        expect(person_without_participants.decorate.all_organizer_events).to be_empty
+      end
+    end
+  end
 end

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -21,6 +21,14 @@ FactoryGirl.define do
       end
     end
 
+    trait :global_organizer do
+      role Roles::ROLE_ORGANIZER
+    end
+
+    trait :global_reviewer do
+      role Roles::ROLE_REVIEWER
+    end
+
     factory :admin do
       admin true
     end
@@ -48,5 +56,17 @@ FactoryGirl.define do
         participant.save
       end
     end
+
+    factory :global_organizer_with_event, traits: [ :global_organizer, :organizer ] do
+      transient do
+        event { build(:event) }
+      end
+
+      after(:create) do |person, evaluator|
+        participant = person.organizer_participants.first
+        participant.event = evaluator.event
+        participant.event.save
+      end
+    end    
   end
 end

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -5,6 +5,7 @@ feature "Listing events for different roles" do
   let!(:proposal) { create(:proposal, title: "A Proposal", abstract: 'foo', event: event) }
   let(:normal_user) { create(:person) }
   let(:organizer) { create(:person) }
+  let(:global_organizer) { create(:person, :global_organizer) }
 
   context "As a regular user" do
     scenario "the user should see a link to to the proposals for an event" do
@@ -18,6 +19,14 @@ feature "Listing events for different roles" do
     scenario "the organizer should see a link to the index for managing proposals" do
       create(:participant, role: 'organizer', person: organizer)
       login_user(organizer)
+      visit events_path
+      expect(page).to have_link('1 proposal', href: organizer_event_proposals_path(event))
+    end
+  end
+
+  context 'As a global organizer' do
+    scenario 'without assoc participant the global organizer should see link to index for managing proposals' do
+      login_user(global_organizer)
       visit events_path
       expect(page).to have_link('1 proposal', href: organizer_event_proposals_path(event))
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -147,27 +147,52 @@ describe Person do
     end
   end
 
-  describe '#reviewer?' do
-    let(:person) { create(:person, :reviewer) }
 
-    it 'is true when reviewer for any event' do
-      expect(person).to be_reviewer
-    end
-    it 'is false when not reviewer of any event' do
-      person.participants.map { |p| p.update_attribute(:role, 'not_reviewer') }
-      expect(person).not_to be_reviewer
+  context 'reviewer is not global' do 
+    describe '#reviewer?' do
+      let(:person) { create(:person, :reviewer) }
+
+      it 'is true when reviewer for any event' do
+        expect(person).to be_reviewer
+      end
+      it 'is false when not reviewer of any event' do
+        person.participants.map { |p| p.update_attribute(:role, 'not_reviewer') }
+        expect(person).not_to be_reviewer
+      end
     end
   end
 
-  describe '#organizer?' do
-    let(:person) { create(:person, :organizer) }
+  context 'reviewer is global' do
+    describe '#reviewer?' do
+      let(:person) { create(:person, :global_reviewer) }
 
-    it 'is true when organizer for any event' do
-      expect(person).to be_organizer
+      it 'is true for any event without assoc participants' do
+        expect(person).to be_reviewer
+      end
     end
-    it 'is false when not organizer of any event' do
-      person.participants.map { |p| p.update_attribute(:role, 'not_organizer') }
-      expect(person).not_to be_organizer
+  end
+
+  context 'organizer is not global' do
+    describe '#organizer?' do
+      let(:person) { create(:person, :organizer) }
+
+      it 'is true when organizer for any event' do
+        expect(person).to be_organizer
+      end
+      it 'is false when not organizer of any event' do
+        person.participants.map { |p| p.update_attribute(:role, 'not_organizer') }
+        expect(person).not_to be_organizer
+      end
+    end
+  end
+
+  context 'organizer is global' do
+    describe '#organizer?' do
+      let(:person) { create(:person, :global_organizer) }
+
+      it 'is true for any event without assoc participants' do
+        expect(person).to be_organizer
+      end
     end
   end
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -373,23 +373,26 @@ describe Proposal do
     let!(:proposal) { create(:proposal) }
     let!(:reviewer) { create(:person, :reviewer) }
     let!(:organizer) { create(:organizer, event: proposal.event) }
+    let!(:global_organizer) { create(:global_organizer_with_event, event: proposal.event) }
+    let!(:global_reviewer)  { create(:person, :global_reviewer) }
 
     it "can return the list of reviewers" do
       create(:rating, person: reviewer, proposal: proposal)
       proposal.public_comments.create(attributes_for(:comment, person: organizer))
 
-      expect(proposal.reviewers).to match_array([ reviewer, organizer ])
+      expect(proposal.reviewers).to match_array([ reviewer, organizer, global_organizer, global_reviewer ])
     end
 
     it "does not return uninvolved reviewers" do
-      expect(proposal.reviewers).to be_empty
+      expect(proposal.reviewers).to match_array([ global_organizer, global_reviewer ])
     end
 
     it "does not list a reviewer more than once" do
       create(:rating, person: reviewer, proposal: proposal)
       proposal.public_comments.create(attributes_for(:comment, person: reviewer))
+      proposal.public_comments.create(attributes_for(:comment, person: global_organizer))
 
-      expect(proposal.reviewers).to match_array([ reviewer ])
+      expect(proposal.reviewers).to match_array([ reviewer, global_organizer, global_reviewer ])
     end
   end
 


### PR DESCRIPTION
PR for Issue #5 - Global 'Organizer' / 'Reviewer' Role. 

The first commit (ee24cbaced253d5b57d9ced5384fbd2f79bb2ec9) fixes a bug in Admin::PeopleController which prevented update of a Person.

The second commit (c53ea2c8cfa22961c072f1d35ca3d497534bc24e) contains the application updates for global roles.

The third commit (7f2f4bf7edc7e3296b3afe0b73086794629327c6) adds new / enhances existing tests concerning this functionality.
